### PR TITLE
Jitter Update

### DIFF
--- a/dLuxToliman/layers/detector_layers.py
+++ b/dLuxToliman/layers/detector_layers.py
@@ -14,7 +14,7 @@ DetectorLayer = lambda: dLux.layers.detector_layers.DetectorLayer
 
 class BaseJitter(DetectorLayer()):
     """
-    Base class for jitter layers.
+    Base class for jitter layers. Apply method applies a convolution.
     """
 
     kernel_size: int
@@ -37,13 +37,13 @@ class BaseJitter(DetectorLayer()):
 
         Parameters
         ----------
-        image : Image
-            The image to operate on.
+        psf : PSF
+            The PSF object to operate on.
 
         Returns
         -------
-        image : Image
-            The transformed image.
+        psf : PSF
+            The convolved PSF object.
         """
         kernel = self.generate_kernel(dLux.utils.rad2arcsec(psf.pixel_scale))
 
@@ -51,13 +51,16 @@ class BaseJitter(DetectorLayer()):
 
     @abstractmethod
     def generate_kernel(self, pixel_scale: float) -> Array:
+        """
+        Generates the convolution kernel to be applied.
+        """
         pass
 
 
 class GaussianJitter(BaseJitter):
     """
-    Convolves the image with a Gaussian kernel parameterised by the standard
-    deviation (sigma).
+    Convolves the image with a multivariate Gaussian kernel parameterised by the
+    magnitude, shear and angle.
 
     Attributes
     ----------
@@ -159,10 +162,8 @@ class GaussianJitter(BaseJitter):
         )
 
         # Compute the covariance matrix
-        covariance_matrix = np.dot(
-            np.dot(R, base_matrix), R.T
-        )
-        
+        covariance_matrix = np.dot(np.dot(R, base_matrix), R.T)
+
         return covariance_matrix
 
     def generate_kernel(self, pixel_scale: float) -> Array:
@@ -232,7 +233,7 @@ class SHMJitter(BaseJitter):
         """
 
         # setting parameters
-        if A < 0.:
+        if A < 0.0:
             raise ValueError("A must be positive")
 
         self.A = A

--- a/dLuxToliman/layers/detector_layers.py
+++ b/dLuxToliman/layers/detector_layers.py
@@ -75,16 +75,16 @@ class GaussianJitter(BaseJitter):
         The oversampling factor for the kernel generation.
     """
 
-    r: float
-    shear: float = None
-    phi: float = None
+    r: float | Array
+    shear: float | Array = None
+    phi: float | Array = None
     kernel_oversample: int
 
     def __init__(
         self: BaseJitter,
-        r: float,
-        shear: float = 0,
-        phi: float = 0,
+        r: float | Array,
+        shear: float | Array = 0,
+        phi: float | Array = 0,
         kernel_size: int = 11,
         kernel_oversample: int = 1,
     ):
@@ -120,9 +120,9 @@ class GaussianJitter(BaseJitter):
 
         super().__init__(kernel_size)
 
-        self.r = r
-        self.shear = shear
-        self.phi = phi
+        self.r = np.array(r)
+        self.shear = np.array(shear)
+        self.phi = np.array(phi)
         self.kernel_oversample = kernel_oversample
 
     @property

--- a/dLuxToliman/layers/detector_layers.py
+++ b/dLuxToliman/layers/detector_layers.py
@@ -8,7 +8,7 @@ from jax.scipy.stats import multivariate_normal
 
 __all__ = ["GaussianJitter", "SHMJitter"]
 
-Image = lambda: dLux.images.Image
+PSF = lambda: dLux.PSFs.PSF
 DetectorLayer = lambda: dLux.layers.detector_layers.DetectorLayer
 
 
@@ -31,7 +31,7 @@ class BaseJitter(DetectorLayer()):
         self.kernel_size = kernel_size
         super().__init__()
 
-    def apply(self: DetectorLayer, image: Image()) -> Image():
+    def apply(self: DetectorLayer, psf: PSF()) -> PSF():
         """
         Applies the layer to the Image.
 
@@ -45,9 +45,9 @@ class BaseJitter(DetectorLayer()):
         image : Image
             The transformed image.
         """
-        kernel = self.generate_kernel(dLux.utils.rad2arcsec(image.pixel_scale))
+        kernel = self.generate_kernel(dLux.utils.rad2arcsec(psf.pixel_scale))
 
-        return image.convolve(kernel)
+        return psf.convolve(kernel)
 
     @abstractmethod
     def generate_kernel(self, pixel_scale: float) -> Array:
@@ -86,7 +86,7 @@ class GaussianJitter(BaseJitter):
         shear: float = 0,
         phi: float = 0,
         kernel_size: int = 11,
-        kernel_oversample: int = 4,
+        kernel_oversample: int = 1,
     ):
         """
         Constructor for the ApplyJitter class.
@@ -161,8 +161,8 @@ class GaussianJitter(BaseJitter):
         # Compute the covariance matrix
         covariance_matrix = np.dot(
             np.dot(R, base_matrix), R.T
-        )  # TODO use dLux.utils.rotate
-
+        )
+        
         return covariance_matrix
 
     def generate_kernel(self, pixel_scale: float) -> Array:

--- a/dLuxToliman/telescopes.py
+++ b/dLuxToliman/telescopes.py
@@ -14,7 +14,7 @@ class Toliman(dLux.Telescope):
 
     Attributes
     ----------
-    osys : dLux.core.BaseOptics
+    optics : dLux.core.BaseOptics
         The optics object to be used in the telescope.
     source : dLux.sources.BaseSource
         The source object to be used in the telescope.
@@ -24,21 +24,21 @@ class Toliman(dLux.Telescope):
     normalise()
     """
 
-    osys: BaseOpticalSystem
+    optics: BaseOpticalSystem
     source: BaseSource
 
-    def __init__(self, osys, source):
+    def __init__(self, optics, source):
         """
         Parameters
         ----------
-        osys : dLux.core.BaseOptics
+        optics : dLux.core.BaseOptics
             The optical system to be used in the telescope.
         source : dLux.sources.BaseSource
             The source object to be used in the telescope.
         """
-        self.osys = osys
+        self.optics = optics
         self.source = source
-        super().__init__(osys, source)
+        super().__init__(optics, source)
 
     def __getattr__(self, key):
         """
@@ -70,7 +70,7 @@ class Toliman(dLux.Telescope):
         watch it die" - L. Desdoigts, 2023.
         """
         # TODO may break in dLux 0.14
-        return self.osys.full_model(self.source)
+        return self.optics.full_model(self.source)
 
     def perturb(self, X, parameters):
         """
@@ -97,7 +97,7 @@ class JitteredToliman(Toliman):
 
     def __init__(
         self,
-        osys,
+        optics,
         source,
         jitter_mag: Array | float,
         jitter_angle: Array | float,
@@ -107,7 +107,7 @@ class JitteredToliman(Toliman):
         """
         Parameters
         ----------
-        osys : dLux.core.BaseOptics
+        optics : dLux.core.BaseOptics
             The optical system to be used in the telescope.
         source : dLux.sources.BaseSource
             The source object to be used in the telescope.
@@ -121,7 +121,7 @@ class JitteredToliman(Toliman):
             The shape of the jitter. Either "linear" or "shm".
         """
 
-        super().__init__(osys, source)  # calling super
+        super().__init__(optics, source)  # calling super
         self.jitter_mag = np.array(jitter_mag, dtype=np.float64)
         self.jitter_angle = np.array(jitter_angle, dtype=np.float64)
         if n_psfs < 2:

--- a/dLuxToliman/telescopes.py
+++ b/dLuxToliman/telescopes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import dLux
 import jax.numpy as np
-from jax import vmap
+from jax import vmap, Array
 from dLux import BaseSource, BaseOpticalSystem
 
 
@@ -62,49 +62,6 @@ class Toliman(dLux.Telescope):
         """
         return self.set("source", self.source.normalise())
 
-    def linear_jitter_model(
-        self,
-        magnitude: float,
-        angle: float,
-        n_psfs: int = 5,
-        centre: tuple = (0, 0),
-    ):
-        """
-        Returns a radially jittered PSF by summing a number of shifted PSFs along a straight line.
-
-        Parameters
-        ----------
-        magnitude : float
-            The magnitude, or length, of the jitter in pixels.
-        angle : float, optional
-            The angle of the jitter in radians, by default 0
-        n_psfs : int, optional
-            The number of PSFs to sum, by default 5
-        centre : tuple, optional
-            The centre of the jitter in arcseconds, by default (0,0)
-
-        Returns
-        -------
-        np.ndarray
-            The jittered PSF.
-        """
-
-        centre_and_model = lambda osys, source, x, y: osys.model(
-            source.set(["x_position", "y_position"], [x, y])
-        )
-        vmap_prop = vmap(centre_and_model, in_axes=(None, None, 0, 0))
-        pixel_scale = self.osys.psf_pixel_scale  # TODO this may break in dLux 0.14
-
-        # converting to cartesian angular coordinates
-        x = magnitude / 2 * np.cos(angle)
-        y = magnitude / 2 * np.sin(angle)
-        xs = pixel_scale * np.linspace(-x, x, n_psfs) + centre[0]  # arcseconds
-        ys = pixel_scale * np.linspace(-y, y, n_psfs) + centre[1]  # arcseconds
-
-        psfs = vmap_prop(self.osys, self.source, xs, ys)
-
-        return psfs.sum(0) / n_psfs  # adding and renormalising
-
     def full_model(self):
         """
         "Oh pretty sure that was for modelling the diffraction spikes in the corners as well as the central psf
@@ -123,3 +80,145 @@ class Toliman(dLux.Telescope):
         for parameter, x in zip(parameters, X):
             perturbed_self = self.add(parameter, x)
         return perturbed_self
+
+
+class JitteredToliman(Toliman):
+    """
+    A child class of Toliman to facilitate the modelling of telescope jitter.
+    This is done by modelling and summing offset PSFs - as a result, the compute
+    time increases linearly with the number of PSFs. The jitter is assumed to be
+    either a linear smear of simple harmonic vibration.
+    """
+
+    jitter_mag: Array | float
+    jitter_angle: Array | float
+    n_psfs: int
+    jitter_shape: str
+
+    def __init__(
+        self,
+        osys,
+        source,
+        jitter_mag: Array | float,
+        jitter_angle: Array | float,
+        n_psfs: int = 6,
+        jitter_shape: str = "linear",
+    ):
+        """
+        Parameters
+        ----------
+        osys : dLux.core.BaseOptics
+            The optical system to be used in the telescope.
+        source : dLux.sources.BaseSource
+            The source object to be used in the telescope.
+        jitter_mag : float
+            The magnitude of the jitter in arcseconds.
+        jitter_angle : float
+            The angle of the jitter in degrees.
+        n_psfs : int
+            The number of PSFs to be modelled.
+        jitter_shape : str
+            The shape of the jitter. Either "linear" or "shm".
+        """
+
+        super().__init__(osys, source)  # calling super
+        self.jitter_mag = np.array(jitter_mag, dtype=np.float64)
+        self.jitter_angle = np.array(jitter_angle, dtype=np.float64)
+        if n_psfs < 2:
+            raise ValueError("n_psfs must be greater than 1.")
+        self.n_psfs = n_psfs
+        if jitter_shape not in ["linear", "shm"]:
+            raise ValueError(
+                "Only jitter_shape values of 'linear' or 'shm' are supported."
+            )
+        self.jitter_shape = jitter_shape
+
+    @staticmethod
+    def get_bounds(xs):
+        """
+        Helper method to grab the integration bounds for shm jitter_model.
+        """
+        return np.concatenate(
+            (
+                np.array(
+                    [
+                        xs[0],
+                    ]
+                ),
+                np.array(xs[1:] + xs[:-1]) / 2,
+                np.array(
+                    [
+                        xs[-1],
+                    ]
+                ),
+            )
+        )
+
+    @staticmethod
+    def machine_epsilon(dtype):
+        """
+        Method to fetch machine epsilon for a given dtype (e.g. float32, float64).
+
+        Parameters
+        ----------
+        dtype : np.dtype
+            The dtype to fetch the machine epsilon for.
+        """
+        info = np.finfo(dtype)
+        return info.eps
+
+    def inv_shm(self, x):
+        """
+        Inverse function for the simple harmonic equation x(t) = Asin(t)
+        """
+        return np.arcsin(np.divide(x, self.jitter_mag / 2))
+
+    def centre_and_model(self, x, y):
+        """
+        Function to offset the source and model the PSF. This is vmapped over
+        in the jitter_model method.
+        """
+        recentered_tel = self.set(["x_position", "y_position"], [x, y])
+        return recentered_tel.model()
+
+    def jitter_model(self):
+        """
+        Method to model the jittered PSF. This is done by modelling and summing
+        offset PSFs - as a result, the compute time increases linearly with the
+        number of PSFs. The jitter is assumed to be either a linear smear of
+        simple harmonic vibration. The shape is determined by the `jitter_shape`
+        parameter.
+        """
+        # horizontal and vertical components of the jitter
+        x = np.cos(dLux.utils.deg2rad(self.jitter_angle))
+        y = np.sin(dLux.utils.deg2rad(self.jitter_angle))
+
+        # grabbing machine epsilon to avoid function evaluation at the asymptote
+        eps = self.machine_epsilon(self.jitter_mag.dtype)
+
+        # generating the base array for PSF positions
+        spacing = np.linspace(
+            -self.jitter_mag / 2 + eps, self.jitter_mag / 2 - eps, self.n_psfs
+        )
+
+        # grabbing the x and y positions of the PSFs
+        xs = spacing * x + self.x_position  # arcseconds
+        ys = spacing * y + self.y_position  # arcseconds
+
+        # for linear jitter
+        if self.jitter_shape == "linear":
+            weights = np.ones(self.n_psfs) / self.n_psfs  # equal weighting
+
+        # for simple harmonic jitter
+        if self.jitter_shape == "shm":
+            bounds = self.get_bounds(spacing)  # grabbing bounds for integration
+            # weighting by value of integral between bounds
+            weights = self.inv_shm(bounds[:-1]) - self.inv_shm(bounds[1:])
+            weights /= weights.sum()  # normalising
+
+        # vmapping over all PSF positions
+        psfs = vmap(self.centre_and_model, in_axes=(0, 0))(xs, ys)
+
+        return np.tensordot(
+            psfs, weights, axes=(0, 0)
+        )  # multiplying by weights and summing

--- a/dLuxToliman/telescopes.py
+++ b/dLuxToliman/telescopes.py
@@ -5,7 +5,7 @@ from jax import vmap, Array
 from dLux import BaseSource, BaseOpticalSystem
 
 
-__all__ = ["Toliman"]
+__all__ = ["Toliman", "JitteredToliman"]
 
 
 class Toliman(dLux.Telescope):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,12 @@ name = "dLuxToliman"
 version = "0.3.0"
 description = "A repo to hold the canonical dLux Toliman models."
 readme = "README.md"
+dynamic = ["urls", "classifiers", "authors", "requires-python"]
 
-#[dependencies]
-#dLux = "0.14.*"
-#jax = "*"
-#jaxlib = "*"
-#
-#[test]
-#[scripts]
+[dependencies]
+dLux = "0.14.*"
+jax = "*"
+jaxlib = "*"
+
+[test]
+[scripts]


### PR DESCRIPTION
Removing the `linear_jitter_model` method from the `Toliman` instrument and instead creating a separate `JitteredToliman` instrument with similar functionality.